### PR TITLE
Bump GoCardless version

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -2,7 +2,7 @@
 /* Only really necessary if you want to run the tests */
 return [
     "baseUrl" => "https://api-sandbox.gocardless.com/",
-    "gocardlessVersion" => "2014-10-03",
+    "gocardlessVersion" => "2014-11-03",
     "username" => "",
     "password" => ""
 ];


### PR DESCRIPTION
Version 2014-11-03 has been out for a few weeks now. The change in behaviour is:
- In version 2014-10-03, when a payment charge date is specified which is too soon to be valid, the API would silently roll it forward to a valid date
- In version 2014-11-03 and onwards, when a charge date is specified that is not far enough in the future a validation error will be raised

For example, in version 2014-10-03, attempting to take a payment with today as the charge date would succeed but silently set the charge date to 3 working days from now. In version 2014-11-03 a validation error would be returned.
