### PR TITLE
Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "*",


### PR DESCRIPTION
To allow downstream projects to use Guzzle 7, widen requirement on Guzzle version. No code changes appear to be necessary, to use the next major version